### PR TITLE
fix: remove circular SVG ring from photo for light theme

### DIFF
--- a/src/components/Photo.tsx
+++ b/src/components/Photo.tsx
@@ -17,37 +17,18 @@ const Photo = () => {
                     },
                 }}
             >
-                {/* Image — no mix-blend-lighten, clean on light background */}
-                <div className="w-[310px] h-[310px] xl:w-[510px] xl:h-[510px] relative">
+                {/* Image — clean circular photo on light background */}
+                <div className="w-[298px] h-[298px] xl:w-[498px] xl:h-[498px] relative">
                     <Image
                         src="/assets/new_profile.svg"
                         priority
                         quality={100}
                         fill
                         alt="Juan Muñoz"
-                        className="pt-[23px] pb-[8px] pr-[15px] pl-[15px] rounded-full"
+                        className="rounded-full object-cover"
                         fetchPriority="high"
                     />
                 </div>
-                {/* Static subtle ring — no spinning animation */}
-                <svg
-                    className="absolute top-0 left-0 w-[310px] xl:w-[510px] h-[310px] xl:h-[510px]"
-                    fill="transparent"
-                    viewBox="0 0 506 506"
-                    xmlns="http://www.w3.org/2000/svg"
-                    aria-hidden="true"
-                >
-                    <circle
-                        cx="253"
-                        cy="253"
-                        r="250"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        className="text-primary/20"
-                    />
-                </svg>
             </motion.div>
         </div>
     )


### PR DESCRIPTION
## Qué cambia

Elimina el aro circular SVG que envolvía la foto. Con el nuevo tema claro editorial, el aro no aportaba y distorsionaba la imagen.

### Cambios
- Eliminado el SVG `<circle>` que rodeaba la foto
- Imagen ahora es `rounded-full` limpia sin decoración extra
- Ajustadas dimensiones del contenedor (298px → se ve más natural sin el padding que necesitaba el aro)

### Antes
Foto envuelta en aro `text-primary/20` apenas visible en fondo claro.

### Después
Foto circular limpia, centrada en el diseño editorial.