### PR TITLE
feat: add Cloudflare Turnstile anti-spam protection to contact form

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -12,6 +12,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { FormSchema, type FormSchemaType, SERVICES, type ServiceType } from "@/lib/schema"
 import { useSearchParams } from "next/navigation";
 import { sendContactEmail } from "@/lib/actions/contact";
+import { TurnstileWidget } from "@/components/TurnstileWidget";
 
 const info = [
     {
@@ -40,9 +41,10 @@ const ContactForm: React.FC = () => {
             },
         }
     )
+    const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
     const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
     const [error, setError] = useState<string | null>(null);
-    const [success, setSuccess] = useState<string | null>(null)
+    const [success, setSuccess] = useState<string | null>(null);
 
     // Pre-select service from query param (e.g. coming from /services page)
     useEffect(() => {
@@ -56,12 +58,19 @@ const ContactForm: React.FC = () => {
     const sendDataAPI = async (dataForm: FormSchemaType) => {
         setError(null);
         setSuccess(null);
+
+        if (!turnstileToken) {
+            setError("Please complete the security check to verify you're not a bot.");
+            return;
+        }
+
         setIsSubmitting(true);
 
-        const result = await sendContactEmail(dataForm);
+        const result = await sendContactEmail({ ...dataForm, turnstileToken });
 
         if (result.success) {
             reset();
+            setTurnstileToken(null);
             setSuccess(result.message);
         } else {
             setError(result.message);
@@ -140,6 +149,14 @@ const ContactForm: React.FC = () => {
                     className="h-[200px]"
                     placeholder="Type your message here.."
                     {...register('message')}
+                />
+            </div>
+
+            {/* Turnstile anti-bot check */}
+            <div className="flex flex-col gap-1">
+                <TurnstileWidget
+                    siteKey="0x4AAAAAAD7e-vZweYFqBF1R"
+                    onVerify={setTurnstileToken}
                 />
             </div>
 

--- a/src/components/TurnstileWidget.tsx
+++ b/src/components/TurnstileWidget.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (container: HTMLElement, options: TurnstileOptions) => string;
+      reset: (widgetId: string) => void;
+      remove: (widgetId: string) => void;
+    };
+  }
+}
+
+interface TurnstileOptions {
+  sitekey: string;
+  callback?: (token: string) => void;
+  "expired-callback"?: () => void;
+  "error-callback"?: () => void;
+  theme?: "light" | "dark" | "auto";
+  tabindex?: number;
+  "refresh-expired"?: "auto" | "manual" | "never";
+  "data-action"?: string;
+}
+
+interface TurnstileWidgetProps {
+  siteKey: string;
+  onVerify: (token: string | null) => void;
+  theme?: "light" | "dark" | "auto";
+}
+
+export function TurnstileWidget({ siteKey, onVerify, theme = "auto" }: TurnstileWidgetProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const widgetIdRef = useRef<string | undefined>(undefined);
+  const scriptLoadedRef = useRef<boolean>(false);
+
+  const handleExpired = useCallback(() => {
+    onVerify(null);
+  }, [onVerify]);
+
+  const handleError = useCallback(() => {
+    onVerify(null);
+  }, [onVerify]);
+
+  useEffect(() => {
+    if (scriptLoadedRef.current) return;
+
+    const initWidget = () => {
+      if (!window.turnstile || !containerRef.current) return;
+      
+      widgetIdRef.current = window.turnstile.render(containerRef.current, {
+        sitekey: siteKey,
+        callback: (token: string) => onVerify(token),
+        "expired-callback": handleExpired,
+        "error-callback": handleError,
+        theme,
+        "refresh-expired": "auto",
+        "data-action": "turnstile-spin-v1",
+      });
+    };
+
+    if (document.getElementById("cf-turnstile-script")) {
+      scriptLoadedRef.current = true;
+      // Script is already loading or loaded; wait for turnstile to be ready
+      const check = setInterval(() => {
+        if (window.turnstile) {
+          clearInterval(check);
+          initWidget();
+        }
+      }, 100);
+      return () => clearInterval(check);
+    }
+
+    const script = document.createElement("script");
+    script.id = "cf-turnstile-script";
+    script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+    script.async = true;
+    script.defer = true;
+    script.onload = () => {
+      scriptLoadedRef.current = true;
+      initWidget();
+    };
+    document.head.appendChild(script);
+
+    return () => {
+      if (widgetIdRef.current && window.turnstile) {
+        window.turnstile.remove(widgetIdRef.current);
+      }
+    };
+  }, [siteKey, onVerify, handleExpired, handleError, theme]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="cf-turnstile"
+      data-action="turnstile-spin-v1"
+    />
+  );
+}

--- a/src/lib/actions/contact.ts
+++ b/src/lib/actions/contact.ts
@@ -3,9 +3,38 @@
 import { Resend } from "resend";
 import { FormSchema, type FormSchemaType } from "@/lib/schema";
 
-export async function sendContactEmail(data: FormSchemaType) {
+const WORKER_URL = "https://turnstile-siteverify-porfolio-nextjs.cl-jmunoz.workers.dev";
+
+export async function sendContactEmail(
+  data: FormSchemaType & { turnstileToken: string },
+) {
   const validated = FormSchema.parse(data);
 
+  // Verify Turnstile token via the siteverify Worker
+  try {
+    const verifyRes = await fetch(WORKER_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: data.turnstileToken }),
+    });
+    const verifyData = await verifyRes.json();
+
+    if (!verifyData.success) {
+      console.warn("Turnstile verification failed:", verifyData["error-codes"]);
+      return {
+        success: false,
+        message: "Security verification failed. Please try again.",
+      };
+    }
+  } catch (error) {
+    console.error("Turnstile Worker unreachable:", error);
+    return {
+      success: false,
+      message: "Security check unavailable. Please try again later.",
+    };
+  }
+
+  // Token is valid — proceed with email
   const resend = new Resend(process.env.RESEND_API_KEY);
 
   try {
@@ -26,6 +55,9 @@ export async function sendContactEmail(data: FormSchemaType) {
     return { success: true, message: "Message sent successfully!" };
   } catch (error) {
     console.error("Resend error:", error);
-    return { success: false, message: "Something went wrong. Please try again." };
+    return {
+      success: false,
+      message: "Something went wrong. Please try again.",
+    };
   }
 }


### PR DESCRIPTION
## Problema

El formulario de `/contact` no tenía protección antispam. Bots hacían POST directo a la server action, pasaban la validación de Zod (mínimos triviales), y el email se enviaba vía Resend. Resultado: correos basura como este:

```
Name: NoERelJdwBIDZGKuZleSO wOvjBEQPHLnHaGFAJQ
Email: at.a.na.xa.w.u.m.8.96@gmail.com
Service: Web Development
Message: JglFTHETckRGOqvCsfqHv
```

## Solución

Se implementó **Cloudflare Turnstile** (modo managed, invisible para usuarios reales):

### Cambios

| Archivo | Cambio |
|---|---|
| `src/components/TurnstileWidget.tsx` | Nuevo componente React que renderiza el widget Turnstile y expone el token |
| `src/app/contact/page.tsx` | Agregado widget + gating: si no hay token válido, no se envía |
| `src/lib/actions/contact.ts` | Server action valida token contra Worker de siteverify **antes** de llamar a Resend |

### Flujo

```
Usuario completa form → Turnstile genera token (invisible) →
Server action → Worker de Cloudflare valida token contra siteverify →
✅ Token válido → se envía email con Resend
❌ Token inválido → se rechaza, no se llama a Resend
```

### Recursos en Cloudflare

- **Widget Turnstile:** `0x4AAAAAAD7e-vZweYFqBF1R`
- **Worker siteverify:** `https://turnstile-siteverify-porfolio-nextjs.cl-jmunoz.workers.dev`
- **Dominios:** `localhost`, `127.0.0.1`, `juancode.dev`

## Verificación

- ✅ Worker siteverify responde health check
- ✅ Dummy token es rechazado correctamente (`invalid-input-response`)
- ✅ Widget domains configurados correctamente
- ✅ TypeScript compila sin errores (los 3 archivos nuevos/modificados)